### PR TITLE
Receives admin password as argument

### DIFF
--- a/install-unity.py
+++ b/install-unity.py
@@ -132,6 +132,10 @@ parser.add_argument('--forget',
     action='append',
     help='remove a manually discovered version')
 
+parser.add_argument('--pwd',
+    nargs='?',
+    help='set admin pwd to be used')
+
 args = parser.parse_args()
 
 # ---- GENERAL ----
@@ -677,7 +681,10 @@ if not operation or operation == 'install':
     # long and the user would have to enter his password again 
     # and again.
     print 'Your admin password is required to install the packages'
-    pwd = getpass.getpass('User password:')
+    if parser.pwd is not None:
+        pwd = parser.pwd
+    else:
+        pwd = getpass.getpass('User password:')
     
     # Check the root password, so that the user won't only find out
     # much later if the password is wrong

--- a/install-unity.py
+++ b/install-unity.py
@@ -681,8 +681,8 @@ if not operation or operation == 'install':
     # long and the user would have to enter his password again 
     # and again.
     print 'Your admin password is required to install the packages'
-    if parser.pwd is not None:
-        pwd = parser.pwd
+    if args.pwd is not None:
+        pwd = args.pwd
     else:
         pwd = getpass.getpass('User password:')
     


### PR DESCRIPTION
We're using your script to install Unity in our Jenkins network. The issue is that the process must be non interactive in order to work properly. We created a new optional argument (pwd) that will receive the password to be used.
