### PR TITLE
Fix select_package missing version

### DIFF
--- a/install-unity.py
+++ b/install-unity.py
@@ -579,7 +579,7 @@ def load_ini(version):
     config.read(ini_path)
     return config
 
-def select_packages(config, packages):
+def select_packages(version, config, packages):
     available = config.sections()
     
     if len(packages) == 0:
@@ -935,7 +935,7 @@ def main():
                     if len(packages) > 0:
                         print 'Using saved default packages'
                 
-                selected = select_packages(config, packages)
+                selected = select_packages(version, config, packages)
                 if len(selected) == 0:
                     print 'WARNING: No packages selected for version %s' % version
                     continue


### PR DESCRIPTION
If you use a package name that doesn't exist (e.g. I had "tvOS" instead of "AppleTV") you get an exception. This is because `select_packages` fails to find the package and tries to print this warning:

```print 'WARNING: Unity version %s has no package "%s"' % (version, select)```

`version` is not in the global scope at this point, so it fails.