### PR TITLE
Fixed whitespace bug when building for android

### DIFF
--- a/Command/Command.csproj
+++ b/Command/Command.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Version>2.12.1</Version>
+    <Version>2.12.2</Version>
     <Authors>Adrian Stutz (sttz.ch)</Authors>
     <Product>install-unity CLI</Product>
     <Description>CLI for install-unity unofficial Unity installer library</Description>

--- a/sttz.InstallUnity/Installer/Configuration.cs
+++ b/sttz.InstallUnity/Installer/Configuration.cs
@@ -62,9 +62,9 @@ public class Configuration
 
     [Description("Mac installation paths, separated by ; (first non-existing will be used, variables: {major} {minor} {patch} {type} {build} {hash}).")]
     public string installPathMac = 
-          "/Applications/Unity {major}.{minor};"
-        + "/Applications/Unity {major}.{minor}.{patch}{type}{build};"
-        + "/Applications/Unity {major}.{minor}.{patch}{type}{build} ({hash})";
+          "/Applications/Unity{major}.{minor};"
+        + "/Applications/Unity{major}.{minor}.{patch}{type}{build};"
+        + "/Applications/Unity{major}.{minor}.{patch}{type}{build}({hash})";
 
     // -------- Serialization --------
 


### PR DESCRIPTION
Never versions of Unity does not support whitespace when building for Android. 

After some googling I decided to fork your repo and try this theory for myself and it turns out to be right. After changing install paths to not use whitespace it is now working.

Let me know if you have a test version that we can try :)